### PR TITLE
chore: remove file_id from metadata.

### DIFF
--- a/backend/service.did
+++ b/backend/service.did
@@ -23,9 +23,12 @@ type who_am_i_response = variant {
   unknown_user;
 };
 
-type request_info = record {
-    file_id;
+type get_alias_info_response = variant {
+  not_found;
+  found: record {
+    file_id: file_id;
     file_name: text;
+  }
 };
 
 type download_file_response = variant {
@@ -53,7 +56,7 @@ service docutrack : {
 
   // Based on the alias (or download link) of the file,
   // it returns the name and id of the file to be uploaded.
-  get_request_info: (alias: text) -> (request_info);
+  get_alias_info: (alias: text) -> (get_alias_info_response);
 
   upload_file: (file_id, blob) -> (upload_file_response) ;
 

--- a/backend/service.did
+++ b/backend/service.did
@@ -1,5 +1,7 @@
+type file_id = nat64;
+
 type file_metadata = record {
-  file_id : nat64;
+  file_id;
   file_name : text;
 };
 
@@ -22,7 +24,7 @@ type who_am_i_response = variant {
 };
 
 type request_info = record {
-    file_id: nat64;
+    file_id;
     file_name: text;
 };
 
@@ -53,9 +55,9 @@ service docutrack : {
   // it returns the name and id of the file to be uploaded.
   get_request_info: (alias: text) -> (request_info);
 
-  upload_file: (nat64, blob) -> (upload_file_response) ;
+  upload_file: (file_id, blob) -> (upload_file_response) ;
 
-  download_file: (nat64) -> (download_file_response) ;
+  download_file: (file_id) -> (download_file_response) ;
 
   get_files: () -> (vec file_metadata);
 }

--- a/backend/src/api/request_file.rs
+++ b/backend/src/api/request_file.rs
@@ -45,7 +45,6 @@ mod test {
             btreemap! {
                 0 => File {
                     metadata: FileMetadata {
-                        file_id: 0,
                         file_name: "request".to_string(),
                     },
                     contents: None

--- a/backend/src/api/request_file.rs
+++ b/backend/src/api/request_file.rs
@@ -9,7 +9,6 @@ pub fn request_file(caller: Principal, request_name: String, state: &mut State) 
 
     let file = File {
         metadata: FileMetadata {
-            file_id,
             file_name: request_name,
         },
         contents: None,

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -31,7 +31,15 @@ pub struct FileMetadata {
 }
 
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct RequestInfo {
+pub enum GetAliasInfoResponse {
+    #[serde(rename = "not_found")]
+    NotFound,
+    #[serde(rename = "found")]
+    Found(AliasInfo)
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct AliasInfo {
     pub file_id: u64,
     pub file_name: String,
 }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -27,6 +27,11 @@ pub enum WhoamiResponse {
 /// File metadata.
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct FileMetadata {
+    pub file_name: String,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct RequestInfo {
     pub file_id: u64,
     pub file_name: String,
 }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -35,7 +35,7 @@ pub enum GetAliasInfoResponse {
     #[serde(rename = "not_found")]
     NotFound,
     #[serde(rename = "found")]
-    Found(AliasInfo)
+    Found(AliasInfo),
 }
 
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -41,16 +41,13 @@ fn get_files() -> Vec<FileMetadata> {
 }
 
 #[query]
-fn get_request_info(alias: String) -> RequestInfo {
+fn get_alias_info(alias: String) -> GetAliasInfoResponse {
     with_state(|s| match s.file_alias_index.get(&alias) {
-        Some(file_id) => RequestInfo {
+        Some(file_id) => GetAliasInfoResponse::Found(AliasInfo {
             file_id: *file_id,
             file_name: s.file_data.get(file_id).unwrap().metadata.file_name.clone(),
-        },
-        None => RequestInfo {
-            file_id: 0,
-            file_name: "non-existing file".to_string(),
-        },
+        }),
+        None => GetAliasInfoResponse::NotFound,
     })
 }
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -41,10 +41,13 @@ fn get_files() -> Vec<FileMetadata> {
 }
 
 #[query]
-fn get_request_info(alias: String) -> FileMetadata {
+fn get_request_info(alias: String) -> RequestInfo {
     with_state(|s| match s.file_alias_index.get(&alias) {
-        Some(file_id) => s.file_data.get(file_id).unwrap().metadata.clone(),
-        None => FileMetadata {
+        Some(file_id) => RequestInfo {
+            file_id: *file_id,
+            file_name: s.file_data.get(file_id).unwrap().metadata.file_name.clone(),
+        },
+        None => RequestInfo {
             file_id: 0,
             file_name: "non-existing file".to_string(),
         },


### PR DESCRIPTION
The file id was stored twice: in the key of the map and in the value. This refactor removes the redundant storage of file IDs.