### PR TITLE
update libraries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "ic-docutrack",
       "workspaces": [
         "frontend"
       ]
@@ -745,25 +746,25 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.6.0.tgz",
-      "integrity": "sha512-SiY+JVid3SABzksiw4TVOO7+c3z02qFd2aD6T3DO2VScLjrml+C0B9B+QAMLuAPKAuDwmRamPRHURKvFktLbfA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.10.0.tgz",
+      "integrity": "sha512-0P35zHrByfbF3Ym3RdQL+RvzgsCDSyO3imSwuZ67XAD5HoCQFF3a8Mhh0V3sObz3rc5aJd4Qn82UpAihJqZ6gQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte": "^2.0.0",
         "@types/cookie": "^0.5.1",
         "cookie": "^0.5.0",
-        "devalue": "^4.2.3",
+        "devalue": "^4.3.0",
         "esm-env": "^1.0.0",
         "kleur": "^4.1.5",
-        "magic-string": "^0.27.0",
+        "magic-string": "^0.30.0",
         "mime": "^3.0.0",
         "sade": "^1.8.1",
         "set-cookie-parser": "^2.5.1",
         "sirv": "^2.0.2",
         "tiny-glob": "^0.2.9",
-        "undici": "5.18.0"
+        "undici": "5.20.0"
       },
       "bin": {
         "svelte-kit": "svelte-kit.js"
@@ -774,6 +775,18 @@
       "peerDependencies": {
         "svelte": "^3.54.0",
         "vite": "^4.0.0"
+      }
+    },
+    "node_modules/@sveltejs/kit/node_modules/magic-string": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
+      "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@sveltejs/vite-plugin-svelte": {
@@ -3589,9 +3602,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.18.0.tgz",
-      "integrity": "sha512-1iVwbhonhFytNdg0P4PqyIAXbdlVZVebtPDvuM36m66mRw4OGrCm2MYynJv/UENFLdP13J1nPVQzVE2zTs1OeA==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
       "dev": true,
       "dependencies": {
         "busboy": "^1.6.0"
@@ -4194,24 +4207,35 @@
       "requires": {}
     },
     "@sveltejs/kit": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.6.0.tgz",
-      "integrity": "sha512-SiY+JVid3SABzksiw4TVOO7+c3z02qFd2aD6T3DO2VScLjrml+C0B9B+QAMLuAPKAuDwmRamPRHURKvFktLbfA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.10.0.tgz",
+      "integrity": "sha512-0P35zHrByfbF3Ym3RdQL+RvzgsCDSyO3imSwuZ67XAD5HoCQFF3a8Mhh0V3sObz3rc5aJd4Qn82UpAihJqZ6gQ==",
       "dev": true,
       "requires": {
         "@sveltejs/vite-plugin-svelte": "^2.0.0",
         "@types/cookie": "^0.5.1",
         "cookie": "^0.5.0",
-        "devalue": "^4.2.3",
+        "devalue": "^4.3.0",
         "esm-env": "^1.0.0",
         "kleur": "^4.1.5",
-        "magic-string": "^0.27.0",
+        "magic-string": "^0.30.0",
         "mime": "^3.0.0",
         "sade": "^1.8.1",
         "set-cookie-parser": "^2.5.1",
         "sirv": "^2.0.2",
         "tiny-glob": "^0.2.9",
-        "undici": "5.18.0"
+        "undici": "5.20.0"
+      },
+      "dependencies": {
+        "magic-string": {
+          "version": "0.30.0",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
+          "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/sourcemap-codec": "^1.4.13"
+          }
+        }
       }
     },
     "@sveltejs/vite-plugin-svelte": {
@@ -6198,9 +6222,9 @@
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
     },
     "undici": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.18.0.tgz",
-      "integrity": "sha512-1iVwbhonhFytNdg0P4PqyIAXbdlVZVebtPDvuM36m66mRw4OGrCm2MYynJv/UENFLdP13J1nPVQzVE2zTs1OeA==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
       "dev": true,
       "requires": {
         "busboy": "^1.6.0"


### PR DESCRIPTION
To avoid vulnerabilities in undici, this PR uses newer versions.

- npm audit fix
- npm install -g npm@9.6.0 