### PR TITLE
move CI to new dfx install action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Install dfx
         uses: dfinity/setup-dfx@main
         with: 
-          dfx-version: "0.15.3"
+          dfx-version: "0.17.0"
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI Checks
 
 env:
   RUST_VERSION: 1.67.0
-  DFX_VERSION: 0.15.0
 
 on:
   push:
@@ -134,13 +133,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install DFX
-        run: |
-          wget --output-document install-dfx.sh "https://internetcomputer.org/install.sh"
-          bash install-dfx.sh < <(yes Y)
-          rm install-dfx.sh
-          dfx cache install
-          echo "$HOME/bin" >> $GITHUB_PATH
+      - name: Install dfx
+        uses: dfinity/setup-dfx@main
+        with: 
+          dfx-version: "0.15.0"
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Install dfx
         uses: dfinity/setup-dfx@main
         with: 
-          dfx-version: "0.15.0"
+          dfx-version: "0.15.3"
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/deps/pulled.json
+++ b/deps/pulled.json
@@ -2,8 +2,9 @@
   "canisters": {
     "rdmx6-jaaaa-aaaaa-aaadq-cai": {
       "name": "internet_identity",
-      "wasm_hash": "9142e876963b4254c3d90bdcbf37f5b0b44d7090f363f2b5bbaf0de714f295ee",
+      "wasm_hash": "f1f2a00beb4d42560943f248178069f71c107afd9f4e59435336099a98e2b10f",
       "init_guide": "Use '(null)' for sensible defaults. See the candid interface for more details.",
+      "init_arg": null,
       "candid_args": "(opt InternetIdentityInit)",
       "gzip": true
     }

--- a/dfx.json
+++ b/dfx.json
@@ -1,5 +1,5 @@
 {
-  "dfx": "0.15.3",
+  "dfx": "0.17.0",
   "canisters": {
     "backend": {
       "type": "rust",


### PR DESCRIPTION
CI is broken because the dfx install script is now interactive