### PR TITLE
fix: meta canoncal, og:url, og:image tags should point to prod urls

### DIFF
--- a/landing-page/astro.config.ts
+++ b/landing-page/astro.config.ts
@@ -3,12 +3,16 @@ import { host, readCanisterIds } from "../frontend/scripts/readCanisterIds";
 
 const canisterIds = readCanisterIds({});
 const hostUrl = new URL(host);
-
+let siteUrl;
 if (hostUrl.port) {
   process.env.PUBLIC_DAPP_URL = `${hostUrl.protocol}//${canisterIds.FRONTEND_CANISTER_ID}.${hostUrl.hostname}:${hostUrl.port}`;
+  siteUrl = `${hostUrl.protocol}//${canisterIds.MARKETING_CANISTER_ID}.${hostUrl.hostname}:${hostUrl.port}`;
 } else {
   process.env.PUBLIC_DAPP_URL = `${hostUrl.protocol}//${canisterIds.FRONTEND_CANISTER_ID}.${hostUrl.hostname}`;
+  siteUrl = `${hostUrl.protocol}//${canisterIds.MARKETING_CANISTER_ID}.${hostUrl.hostname}`;
 }
 
 // https://astro.build/config
-export default defineConfig({});
+export default defineConfig({
+  site: siteUrl,
+});

--- a/landing-page/src/layouts/Layout.astro
+++ b/landing-page/src/layouts/Layout.astro
@@ -22,7 +22,7 @@ import Sprites from '../components/Sprites.astro';
 				basic: {
 					title: `${title} — Request, share, and manage documents`,
 					type: 'website',
-					image: "/social.jpg"
+					image: `${Astro.site.href}social.jpg`
 				}
 			}}
 			extend={{


### PR DESCRIPTION
The meta tags point to localhost URL's. This PR fixes them.


<img width="593" alt="image" src="https://github.com/dfinity/ic-docutrack/assets/9403182/00651f40-8a05-4ca8-bac3-bd639389ba45">
